### PR TITLE
Remove owner_id from schema and fix typo in INSERT statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ INSERT INTO owners (name) VALUES ("mugumogu");
 INSERT INTO owners (name) VALUES ("Sophie");
 INSERT INTO owners (name) VALUES ("Penny");
 INSERT INTO cats (name, age, breed) VALUES ("Maru", 3, "Scottish Fold");
-INSERT INTO cats (name, age, breed) VALUES ("Hana", 3, "Tabby");
+INSERT INTO cats (name, age, breed) VALUES ("Hana", 1, "Tabby");
 INSERT INTO cats (name, age, breed) VALUES ("Nona", 4, "Tortoiseshell" );
 INSERT INTO cats (name, age, breed) VALUES ("Lil' Bub", 2, "perma-kitten");
 ```
@@ -147,7 +147,7 @@ CREATE TABLE cats (
 id INTEGER PRIMARY KEY, 
 name TEXT, 
 age INTEGER,
-owner_id INTEGER, breed TEXT);
+breed TEXT);
 
 CREATE TABLE owners (id INTEGER PRIMARY KEY, name TEXT);
 


### PR DESCRIPTION
When the cats table was created, it had the following columns: id, name, age, and breed. However, in the "Creating the Table" section, the lesson incorrectly shows that running .schema would return a cats table containing an owner_id column. As for the typo, Hana's age was incorrectly set to 3, when the lesson showed earlier that her age is 1.